### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,10 @@ Links
     :target: https://coveralls.io/r/Javex/pyramid_crud?branch=master
     :alt: Coverage Status
 
-.. |LatestVersion| image:: https://pypip.in/v/pyramid_crud/badge.png
+.. |LatestVersion| image:: https://img.shields.io/pypi/v/pyramid_crud.svg
    :target: https://pypi.python.org/pypi/pyramid_crud/
    :alt: Latest Version
 
-.. |License| image:: https://pypip.in/license/pyramid_crud/badge.png
+.. |License| image:: https://img.shields.io/pypi/l/pyramid_crud.svg
     :target: https://pypi.python.org/pypi/pyramid_crud/
     :alt: License


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyramid-crud))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyramid-crud`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.